### PR TITLE
Track specs and allow reloading with said spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ rebar compile ct
 ### Functions
 
 ``` erlang
+-spec set_config(app_name()) -> ok|no_return().
 -spec set_config(app_name(), config_specs()|[]) -> ok|no_return().
 -spec set_config(app_name(), app_key(), env_key()) -> ok|no_return().
 -spec get_config(app_name(), app_key()) -> app_key_value()|no_return().


### PR DESCRIPTION
This is more or less convenience functionality that allows to do a
refresh of a previously set spec without needing to re-submit said spec.

This adds statefulness to stillir, but depending on it is entirely
optional, past the cost impact on hopefully rare configuration setups.

Note that the saving of a piece of spec is only done if it successfuly
set the value in the first place.
