### PR TITLE
Accept periods (full stops) in env values

### DIFF
--- a/src/stillir.erl
+++ b/src/stillir.erl
@@ -149,7 +149,7 @@ read_file(IoDev, Retval) ->
     end.
 
 handle_line(Data) ->
-    case re:split(Data, "^export\s+([A-Z0-9_]+)='?([^'.]*)'?\n$") of
+    case re:split(Data, "^export\s+([A-Z0-9_]+)='?([^']*)'?\n$") of
         [_, EnvKey, EnvVar, _] ->
             {binary_to_list(EnvKey), binary_to_list(EnvVar)};
         Error ->

--- a/test/keys.sh
+++ b/test/keys.sh
@@ -1,3 +1,3 @@
 export CONF1=updated_var1
 export CONF2='updated_var2'
-export CONF3=updated_var3
+export CONF3=updated.var3

--- a/test/stillir_first_SUITE.erl
+++ b/test/stillir_first_SUITE.erl
@@ -140,5 +140,5 @@ update_env(Config) ->
     stillir:update_env(stillir, code:lib_dir(stillir) ++ "/test/keys.sh", Specs),
     "updated_var1" = stillir:get_config(stillir, update_1),
     updated_var2 = stillir:get_config(stillir, update_2),
-    updated_var3 = stillir:get_config(stillir, update_3),
+    'updated.var3' = stillir:get_config(stillir, update_3),
     Config.


### PR DESCRIPTION
The pattern used forbids usage of periods and quotations in env values.
While I can't judge on the usefulness of quotes within quotes at this
point (we'll need a real parser!), I do know that we have variables that
use full stops in there, and the pattern means we can't reload configs.

This patch makes it so instead of accepting all characters but ' and .,
only ' is excluded.