### PR TITLE
Sub config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ rebar compile ct
 
 ``` erlang
 -type app_name() :: atom().
--type app_key() :: atom().
+-type app_key() :: atom() | [atom()].
 -type env_key() :: string().
 -type env_var_value() :: string().
 -type app_key_value() :: any().

--- a/src/stillir.erl
+++ b/src/stillir.erl
@@ -165,7 +165,10 @@ set_env_value(AppName, AppKey, _, {value, EnvValue}, Opts) ->
 set_env(AppName, AppKey, Value) when is_atom(AppKey) ->
     application:set_env(AppName, AppKey, Value);
 set_env(AppName, [AppKey | SubKeys], Value) ->
-    Old = application:get_env(AppName, AppKey, []),
+    Old = case application:get_env(AppName, AppKey) of
+              undefined -> [];
+              {ok, Val} -> Val
+          end,
     New = set_sub_env(SubKeys, Value, Old),
     application:set_env(AppName, AppKey, New).
 

--- a/test/stillir_first_SUITE.erl
+++ b/test/stillir_first_SUITE.erl
@@ -141,8 +141,8 @@ set_conf_sub(Config) ->
 
     {'EXIT', {{missing_config, [set_conf_sub, one, none]}, _}} =
         (catch stillir:get_config(stillir, [set_conf_sub, one, none])),
-    {'EXIT', {{missing_config, [set_conf_sub, none]}, _}} =
-        (catch stillir:get_config(stillir, [set_conf_sub, none])),
+    {'EXIT', {{missing_config, [set_conf_sub, two, none]}, _}} =
+        (catch stillir:get_config(stillir, [set_conf_sub, two, none])),
 
     [{a, "one_a"}, {b, "one_b"}, {default, default1}] =
         stillir:get_config(stillir, [set_conf_sub, one]),


### PR DESCRIPTION
Added support for nested proplists sub config, like cuttlefish. 

`app_key` can also be in the form of `[a, b, c]`.
