### PR TITLE
Allowing to use previously set app env vars for configuration

### DIFF
--- a/src/stillir.erl
+++ b/src/stillir.erl
@@ -40,7 +40,8 @@ set_config(AppName, AppKey, EnvKey) ->
                  opts()) -> ok|no_return().
 set_config(AppName, AppKey, EnvKey, Opts) ->
     EnvValue = get_env(EnvKey),
-    set_env_value(AppName, AppKey, EnvKey, EnvValue, Opts).
+    AppEnvValue = get_app_env(AppName, AppKey),
+    set_env_value(AppName, AppKey, EnvKey, EnvValue, AppEnvValue, Opts).
 
 -spec get_config(app_name(), app_key()) -> app_key_value()|no_return().
 get_config(AppName, AppKey) ->
@@ -111,16 +112,24 @@ get_env(EnvKey) ->
             {value, EnvValue}
     end.
 
+get_app_env(AppName, AppKey) ->
+    case application:get_env(AppName, AppKey) of
+        {ok, Value} ->
+            {value, Value};
+        undefined ->
+            missing_app_env_key
+    end.
+
 get_default(Fun) when is_function(Fun, 0) ->
     Fun();
 get_default(Other) ->
     Other.
 
-set_env_value(AppName, AppKey, EnvKey, missing_env_key, Opts) ->
+set_env_value(AppName, AppKey, EnvKey, missing_env_key, missing_app_env_key, Opts) ->
     case proplists:is_defined(default, Opts) of
         true ->
             DefaultValue = get_default(proplists:get_value(default, Opts)),
-            set_env_value(AppName, AppKey, EnvKey, {value, DefaultValue}, Opts);
+            set_env_value(AppName, AppKey, EnvKey, {value, DefaultValue}, missing_app_env_key, Opts);
         false ->
             case proplists:get_value(required, Opts) of
                 true ->
@@ -129,10 +138,12 @@ set_env_value(AppName, AppKey, EnvKey, missing_env_key, Opts) ->
                     ok
             end
     end;
-set_env_value(AppName, AppKey, _, {value, EnvValue}, Opts) ->
+set_env_value(AppName, AppKey, _, {value, EnvValue}, _, Opts) ->
     Transform = proplists:get_value(transform, Opts),
     TransformedValue = transform_value(EnvValue, Transform),
-    set_env(AppName, AppKey, TransformedValue).
+    set_env(AppName, AppKey, TransformedValue);
+set_env_value(AppName, AppKey, _, _, {value, AppEnvValue}, _) ->
+    set_env(AppName, AppKey, AppEnvValue).
 
 set_env(AppName, AppKey, Value) ->
     application:set_env(AppName, AppKey, Value).

--- a/test/stillir_first_SUITE.erl
+++ b/test/stillir_first_SUITE.erl
@@ -11,6 +11,9 @@
 all() ->
     [set_conf_no_default
      ,set_conf_default
+     ,set_conf_app_env
+     ,set_conf_app_env_with_env_var
+     ,set_conf_app_env_with_default
      ,set_conf_transform_fun
      ,set_conf_default_transform_fun
      ,set_conf_default_transform_fun2
@@ -35,6 +38,9 @@ end_per_suite(Config) ->
 %% Runs before the test case. Runs in the same process.
 init_per_testcase(set_conf_no_default, Config) ->
     true = os:putenv("SET_CONF_NO_DEFAULT", "test value 1"),
+    Config;
+init_per_testcase(set_conf_app_env_with_env_var, Config) ->
+    true = os:putenv("SET_CONF_APP_ENV_WITH_ENV_VAR", "bar"),
     Config;
 init_per_testcase(set_conf_transform_fun, Config) ->
     true = os:putenv("SET_CONF_TRANSFORM_FUN", "1000"),
@@ -87,6 +93,26 @@ set_conf_default(Config) ->
                                        end}]),
     default_value = stillir:get_config(stillir, set_conf_default),
     default_value = stillir:get_config(stillir, set_conf_default_2),
+    Config.
+
+set_conf_app_env(Config) ->
+    ok = application:set_env(stillir, set_conf_app_env, foo),
+    ok = stillir:set_config(stillir, set_conf_app_env, "SET_CONF_APP_ENV"),
+    foo = stillir:get_config(stillir, set_conf_app_env),
+    Config.
+
+%% env vars should have priority over previously set app env vars
+set_conf_app_env_with_env_var(Config) ->
+    ok = application:set_env(stillir, set_conf_app_env_with_env_var, foo),
+    ok = stillir:set_config(stillir, set_conf_app_env_with_env_var, "SET_CONF_APP_ENV_WITH_ENV_VAR"),
+    "bar" = stillir:get_config(stillir, set_conf_app_env_with_env_var),
+    Config.
+
+%% previously set app env vars should have priority over a default value in the options
+set_conf_app_env_with_default(Config) ->
+    ok = application:set_env(stillir, set_conf_app_env_with_default, foo),
+    ok = stillir:set_config(stillir, set_conf_app_env_with_default, "SET_CONF_APP_ENV_WITH_DEFAULT", [{default, bar}]),
+    foo = stillir:get_config(stillir, set_conf_app_env_with_default),
     Config.
 
 set_conf_transform_fun(Config) ->


### PR DESCRIPTION
If an app env var has already been defined, we use that over the `default`
option for `stillir:set_config/*`.
Environment variables still have priority over previously defined app env
vars though.

Comes in handy e.g. to configure apps using `stillir` from the `sys.config`
file.

Added tests.