### PR TITLE
Eliminate test compiler warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,5 @@
 %%% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
+{profiles, [
+    {test, [{erl_opts, [nowarn_export_all]}]}
+]}.


### PR DESCRIPTION
exporting all functions results in compiler warnings, which automatically becomes rather noisy for CT suites, so the option is added to mute this in the test profile.